### PR TITLE
Make sure that tray items is a list

### DIFF
--- a/InstagramAPI/src/http/Response/ReelsTrayFeedResponse.py
+++ b/InstagramAPI/src/http/Response/ReelsTrayFeedResponse.py
@@ -10,10 +10,10 @@ class ReelsTrayFeedResponse(Response):
 
         if self.STATUS_OK == response['status']:
             trays = []
-            if 'tray' in response and len(response['tray']):
+            if 'tray' in response and isinstance(response['tray'], list):
                 for tray in response['tray']:
                     items = []
-                    if 'items' in tray and len(tray['items']):
+                    if 'items' in tray and isinstance(tray['items'], list):
                         for item in tray['items']:
                             items.append(Item(item))
 


### PR DESCRIPTION
This fixes an exception when tray['items'] is None. The same conditional check is added for response['tray'].


Error:
```
In [5]: i = Instagram(u, p, debug=False, IGDataPath=None)

In [6]: i.login()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-1d6c03e8b4f0> in <module>()
----> 1 i.login()

/home/luka/workspace/tmp/Instagram-API/virtualenv/lib/python2.7/site-packages/InstagramAPI/src/Instagram.pyc in login(self, force)
    219             self.getv2Inbox()
    220             self.getRecentActivity()
--> 221             self.getReelsTrayFeed()
    222             self.explore()
    223 

/home/luka/workspace/tmp/Instagram-API/virtualenv/lib/python2.7/site-packages/InstagramAPI/src/Instagram.pyc in getReelsTrayFeed(self)
   1147 
   1148     def getReelsTrayFeed(self):
-> 1149         feed = ReelsTrayFeedResponse(self.http.request('feed/reels_tray/')[1])
   1150         if not feed.isOk():
   1151             raise InstagramException(feed.getMessage() + "\n")

/home/luka/workspace/tmp/Instagram-API/virtualenv/lib/python2.7/site-packages/InstagramAPI/src/http/Response/ReelsTrayFeedResponse.pyc in __init__(self, response)
     14                 for tray in response['tray']:
     15                     items = []
---> 16                     if 'items' in tray and len(tray['items']):
     17                         for item in tray['items']:
     18                             items.append(Item(item))

TypeError: object of type 'NoneType' has no len()

```